### PR TITLE
Drop netcoreapp2.1 as it's EOL

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -86,7 +86,7 @@ class Build : NukeBuild
             //      unfortunately we cant use nuke to parse it from the solution file, as our use of things like
             //      "([MSBuild]::IsOSUnixLike())" means that it wont parse
 
-            var targets = new[] { "netstandard2.0", "netcoreapp2.1", "netcoreapp3.1", "net5.0" };
+            var targets = new[] { "netstandard2.0", "netcoreapp3.1", "net5.0" };
             if (EnvironmentInfo.IsWin)
                 targets = targets.Concat("net452").ToArray();
 

--- a/source/CommandLine/CommandLine.csproj
+++ b/source/CommandLine/CommandLine.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>embedded</DebugType>
         <AssemblyName>Octopus.CommandLine</AssemblyName>

--- a/source/CommandLine/Octopus.CommandLine.nuspec
+++ b/source/CommandLine/Octopus.CommandLine.nuspec
@@ -32,7 +32,6 @@
         <file src="icon.png" target="images\" />
         <file src="bin\$configuration$\net452\Octopus.CommandLine.dll" target="lib\net452" />
         <file src="bin\$configuration$\net5.0\Octopus.CommandLine.dll" target="lib\net5.0" />
-        <file src="bin\$configuration$\netcoreapp2.1\Octopus.CommandLine.dll" target="lib\netcoreapp2.1" />
         <file src="bin\$configuration$\netcoreapp3.1\Octopus.CommandLine.dll" target="lib\netcoreapp3.1" />
         <file src="bin\$configuration$\netstandard2.0\Octopus.CommandLine.dll" target="lib\netstandard2.0" />
     </files>

--- a/source/CommandLine/Octopus.CommandLine.nuspec
+++ b/source/CommandLine/Octopus.CommandLine.nuspec
@@ -17,9 +17,6 @@
             <group targetFramework=".NETFramework4.5.2">
                 <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
             </group>
-            <group targetFramework=".NETCoreApp2.1">
-                <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
-            </group>
             <group targetFramework=".NETCoreApp3.1">
                 <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
             </group>


### PR DESCRIPTION
We are planning on dropping dotnet 2.1 from our build agents - we want to remove all references before we do.