### PR TITLE
Fix up injected powershell script to have consistent indent

### DIFF
--- a/source/CommandLine/ShellCompletion/PowershellCompletionInstallerBase.cs
+++ b/source/CommandLine/ShellCompletion/PowershellCompletionInstallerBase.cs
@@ -27,7 +27,7 @@ namespace Octopus.CommandLine.ShellCompletion
                     results.AppendLine($"Register-ArgumentCompleter -Native -CommandName {command} -ScriptBlock {{");
                     results.AppendLine("    param($wordToComplete, $commandAst, $cursorPosition)");
                     results.AppendLine("    $params = $commandAst.ToString().Split(' ') | Select-Object -skip 1");
-                    results.AppendLine($"   & \"{exePath}\" complete $params | ForEach-Object {{");
+                    results.AppendLine($"    & \"{exePath}\" complete $params | ForEach-Object {{");
                     results.AppendLine("        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterName', $_)");
                     results.AppendLine("    }");
                     results.AppendLine("}");


### PR DESCRIPTION
The powershell code snippet we injected was slightly misaligned.

(This was an old code change I had sitting around from many moons ago)