### PR TITLE
Show error if executable moved

### DIFF
--- a/source/CommandLine/ShellCompletion/ShellCompletionInstaller.cs
+++ b/source/CommandLine/ShellCompletion/ShellCompletionInstaller.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Octopus.CommandLine.Commands;
 using Octopus.CommandLine.Extensions;
 using Octopus.CommandLine.Plumbing;
 
@@ -49,6 +50,13 @@ namespace Octopus.CommandLine.ShellCompletion
                 {
                     if (profileText.Contains(AllShellsPrefix) || profileText.Contains(AllShellsSuffix) || profileText.Contains(ProfileScript))
                     {
+                        if (!profileText.Contains(ProfileScript)){
+                            var message =
+                                $"Looks like command line completion is already installed, but points to a different executable.{Environment.NewLine}" +
+                                $"Please manually edit the file {ProfileLocation} to remove the existing auto complete script and then re-install.";
+                            throw new CommandException(message);
+                        }
+
                         commandOutputProvider.Information("Looks like command line completion is already installed. Nothing to do.");
                         return;
                     }


### PR DESCRIPTION
If the auto-complete snippet start/end markers exist, but the text doesn't match, then show a nice message to say that it needs to be manually resolved.

This happened when I was testing locally - shouldn't happen too often for customers in the real world.

(This was an old code change I had sitting around from many moons ago)