### PR TITLE
Upgrade to dotnet6 and net462

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "nuke.globaltool": {
+      "version": "6.0.2",
+      "commands": [
+        "nuke"
+      ]
+    }
+  }
+}

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -6,6 +6,10 @@
     "build": {
       "type": "object",
       "properties": {
+        "AutoDetectBranch": {
+          "type": "boolean",
+          "description": "Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI"
+        },
         "Configuration": {
           "type": "string",
           "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
@@ -45,6 +49,10 @@
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
+        },
+        "OCTOVERSION_CurrentBranch": {
+          "type": "string",
+          "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
         },
         "Partition": {
           "type": "string",

--- a/build.ps1
+++ b/build.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -99,7 +99,7 @@ class Build : NukeBuild
             //      unfortunately we cant use nuke to parse it from the solution file, as our use of things like
             //      "([MSBuild]::IsOSUnixLike())" means that it wont parse
 
-            var targets = new[] { "netstandard2.0", "netcoreapp3.1", "net5.0", "net6.0" };
+            var targets = new[] { "netstandard2.0", "netcoreapp3.1", "net6.0" };
             if (EnvironmentInfo.IsWin)
                 targets = targets.Concat("net462").ToArray();
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="5.3.0" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.438" />
+    <PackageReference Include="Nuke.Common" Version="6.0.1" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.1058]" />
   </ItemGroup>
 
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageReference Include="Nuke.Common" Version="6.0.2" />
     <PackageReference Include="ILRepack" Version="2.0.18" />
     <PackageDownload Include="OctoVersion.Tool" Version="[0.2.1058]" />
   </ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.303",
+    "version": "6.0.102",
     "rollForward": "latestFeature"
   }
 }

--- a/source/CommandLine/CommandLine.csproj
+++ b/source/CommandLine/CommandLine.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net462;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net462;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>embedded</DebugType>
         <AssemblyName>Octopus.CommandLine</AssemblyName>

--- a/source/CommandLine/CommandLine.csproj
+++ b/source/CommandLine/CommandLine.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net452;netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
-        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net5.0</TargetFrameworks>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net462;netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <DebugType>embedded</DebugType>
         <AssemblyName>Octopus.CommandLine</AssemblyName>

--- a/source/CommandLine/Octopus.CommandLine.nuspec
+++ b/source/CommandLine/Octopus.CommandLine.nuspec
@@ -14,13 +14,13 @@
         <copyright>Copyright © Octopus Deploy 2021</copyright>
         <repository url="https://github.com/OctopusDeploy/CommandLine" />
         <dependencies>
-            <group targetFramework=".NETFramework4.5.2">
+            <group targetFramework=".NETFramework4.6.2">
                 <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
             </group>
             <group targetFramework=".NETCoreApp3.1">
                 <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
             </group>
-            <group targetFramework="net5.0">
+            <group targetFramework="net6.0">
                 <dependency id="Serilog" version="2.3.0" exclude="Build,Analyzers" />
             </group>
             <group targetFramework=".NETStandard2.0">
@@ -30,8 +30,8 @@
     </metadata>
     <files>
         <file src="icon.png" target="images\" />
-        <file src="bin\$configuration$\net452\Octopus.CommandLine.dll" target="lib\net452" />
-        <file src="bin\$configuration$\net5.0\Octopus.CommandLine.dll" target="lib\net5.0" />
+        <file src="bin\$configuration$\net462\Octopus.CommandLine.dll" target="lib\net462" />
+        <file src="bin\$configuration$\net6.0\Octopus.CommandLine.dll" target="lib\net6.0" />
         <file src="bin\$configuration$\netcoreapp3.1\Octopus.CommandLine.dll" target="lib\netcoreapp3.1" />
         <file src="bin\$configuration$\netstandard2.0\Octopus.CommandLine.dll" target="lib\netstandard2.0" />
     </files>

--- a/source/Octopus.CommandLine.sln
+++ b/source/Octopus.CommandLine.sln
@@ -8,9 +8,10 @@ ProjectSection(SolutionItems) = preProject
 	..\build.ps1 = ..\build.ps1
 	..\build.sh = ..\build.sh
 	..\CONTRIBUTING.md = ..\CONTRIBUTING.md
-	..\GitVersion.yml = ..\GitVersion.yml
 	..\LICENSE.txt = ..\LICENSE.txt
 	..\readme.md = ..\readme.md
+	..\global.json = ..\global.json
+	..\octoversion.json = ..\octoversion.json
 EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{F2E52E31-40D3-4D04-964B-10EB9432BA47}"

--- a/source/Octopus.CommandLine.sln.DotSettings
+++ b/source/Octopus.CommandLine.sln.DotSettings
@@ -247,7 +247,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Namers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nupkg/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octofront/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=OCTOVERSION/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=redirector/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=runbook/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=runbooks/@EntryIndexedValue">True</s:Boolean>

--- a/source/Tests/Commands/HelpCommandFixture.cs
+++ b/source/Tests/Commands/HelpCommandFixture.cs
@@ -47,7 +47,7 @@ namespace Tests.Commands
 
             output.ToString()
                 .Should()
-                .MatchRegex(@"Usage: (dotnet|testhost|ReSharperTestRunner64) <command> \[<options>\]")
+                .MatchRegex(@"Usage: (dotnet|testhost.*|ReSharperTestRunner64) <command> \[<options>\]")
                 .And.Contain("Where <command> is one of:")
                 .And.Contain("create-foo");
         }
@@ -61,7 +61,7 @@ namespace Tests.Commands
 
             output.ToString()
                 .Should()
-                .MatchRegex(@"Usage: (dotnet|testhost|ReSharperTestRunner64) speak \[<options>\]");
+                .MatchRegex(@"Usage: (dotnet|testhost.*|ReSharperTestRunner64) speak \[<options>\]");
         }
 
         [Test]

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFrameworks Condition="!$([MSBuild]::IsOSUnixLike())">net462;netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
+        <TargetFrameworks Condition="$([MSBuild]::IsOSUnixLike())">netstandard2.0;netcoreapp3.1;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
dotnet5 is going EOL very soon (May 8, 2022)
.net 4.5.2 went EOL on April 26.

This PR upgrades to dotnet6, and the nuke 6.0.2

Note: this modifies the build process to use the dotnet tool from the project if running against the `mattr/dotnet6` branch, rather than the global one. We'll need to drop the old one once this merges.