### PR TITLE
Add main to non prerelease tags

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-    "NonPreReleaseTags": ["refs/heads/main", "refs/heads/master"]
+    "NonPreReleaseTags": ["main", "refs/heads/main"]
 }


### PR DESCRIPTION
Release versions are getting tagged with `-main`